### PR TITLE
feat: add batch sending to avoid Feishu card 100KB size limit

### DIFF
--- a/lark_post.py
+++ b/lark_post.py
@@ -12,61 +12,67 @@ def post_to_lark_webhook(tag: str, papers: list, config: dict):
         'Content-Type': 'application/json'
     }
 
-    # Card Template Data
-    today_date = datetime.date.today().strftime('%Y-%m-%d')
-    table_rows = [
-        {
-            "index": i + 1,
-            "title": paper['title'],
-            "id": paper['id'],
-            "published": paper['published'],
-            "url": f"[{paper['url']}]({paper['url']})"
-        }
-        for i, paper in enumerate(papers)
-    ]
-    paper_list = [
-        {
-            "counter": i + 1,
-            "title": paper['title'],
-            "id": paper['id'],
-            "abstract": paper['abstract'],
-            "zh_abstract": paper.get('zh_abstract', None),
-            "url": paper['url'],
-            "published": paper['published']
-        }
-        for i, paper in enumerate(papers)
-    ]
+    # 因为飞书卡片有 100KB 容量限制，如果论文太多（比如超过10篇连带长摘要），很容易超限
+    # 将长列表进行分批发送，每批最多 10 篇
+    batch_size = 10
+    total_batches = (len(papers) + batch_size - 1) // batch_size
 
-    card_data = {
-        "type": "template",
-        "data": {
-            "template_id": config['template_id'],
-            "template_version_name": config['template_version_name'],
-            "template_variable": {
-                "today_date": today_date,
-                "tag": tag,
-                "total_paper": len(papers),
-                "table_rows": table_rows,
-                "paper_list": paper_list
+    for batch_idx in range(total_batches):
+        batch_papers = papers[batch_idx * batch_size : (batch_idx + 1) * batch_size]
+        
+        # 组装这批卡片数据
+        today_date = datetime.date.today().strftime('%Y-%m-%d')
+        table_rows = [
+            {
+                "index": i + 1 + batch_idx * batch_size,
+                "title": paper['title'],
+                "id": paper['id'],
+                "published": paper['published'],
+                "url": f"[{paper['url']}]({paper['url']})"
+            }
+            for i, paper in enumerate(batch_papers)
+        ]
+        paper_list = [
+            {
+                "counter": i + 1 + batch_idx * batch_size,
+                "title": paper['title'],
+                "id": paper['id'],
+                "abstract": paper['abstract'],
+                "zh_abstract": paper.get('zh_abstract', None),
+                "url": paper['url'],
+                "published": paper['published']
+            }
+            for i, paper in enumerate(batch_papers)
+        ]
+
+        card_data = {
+            "type": "template",
+            "data": {
+                "template_id": config['template_id'],
+                "template_version_name": config['template_version_name'],
+                "template_variable": {
+                    "today_date": f"{today_date} (Part {batch_idx + 1}/{total_batches})" if total_batches > 1 else today_date,
+                    "tag": tag,
+                    "total_paper": len(batch_papers),
+                    "table_rows": table_rows,
+                    "paper_list": paper_list
+                }
             }
         }
-    }
 
-    data = {
-        "msg_type": "interactive",
-        "card": card_data
-    }
+        data = {
+            "msg_type": "interactive",
+            "card": card_data
+        }
 
-    # Send HTTP POST request
-    response = requests.post(config['webhook_url'], headers=headers, data=json.dumps(data))
+        # Send HTTP POST request
+        response = requests.post(config['webhook_url'], headers=headers, data=json.dumps(data))
 
-    if response.status_code == 200:
-        print("Request successful")
-        print("Response:\n{}".format(response.json()))
-    else:
-        print("Request failed, status code: {}".format(response.status_code))
-        print("Response:\n{}".format(response.text))
-
+        if response.status_code == 200:
+            print(f"Batch {batch_idx + 1}/{total_batches} - Request successful")
+        else:
+            print(f"Batch {batch_idx + 1}/{total_batches} - Request failed, status code: {response.status_code}")   
+            print("Response:\n{}".format(response.text))
 
 if __name__ == '__main__':
     papers = [


### PR DESCRIPTION
### What does this PR do?
This PR introduces a pagination/batching mechanism in `lark_post.py` to prevent the Feishu (Lark) custom bot from failing when trying to send a large number of filtered papers.

### Why is this needed?
If the daily filtered list `papers.json` contains a large number of papers (especially with translated abstracts), the generated message card data often exceeds Feishu's strict `100KB` card size limit. This causes the webhook sequence to fail entirely and throw the following error constraint before sending anything:

> `{'code': 11246, 'data': {}, 'msg': 'ErrCode: 100000; ErrMsg: card content size is over limit, the mas size is 100kb; '}`

### How was this implemented?
1. Calculated the `total_batches` required to send the `papers` list, using chunks of a configurable `batch_size` (set to 10 papers per batch).
2. The logic iterates through the split chunks and fires separate, valid-size HTTP POST requests sequentially to the Lark Webhook URL.
3. Appended an indicator to the header block `today_date`, showing `(Part X/Y)` to provide context that more papers have been pushed during those parallel dispatches when multiple batches present.

### Test Screenshots
(You can check the modified card layout via the partial indicator logic appended)

As soon as filtering succeeds and finds over ten papers, here are the sequential pushes without breaking:
<img width="923" height="188" alt="f7730b02f8afb19bf17bc3429265c440" src="https://github.com/user-attachments/assets/d0cf84cc-6525-49b1-9b56-88c243811c06" />

<img width="888" height="1348" alt="image" src="https://github.com/user-attachments/assets/578bd23e-8b3f-43ca-92a7-49ddd7467a30" />

<img width="791" height="1927" alt="image" src="https://github.com/user-attachments/assets/dc73515c-00e2-4863-b65d-be5d5a6b97e6" />

> ✨ **As you can see, when there are more than 10 papers, it automatically splits them into multiple parts (e.g. Part 1/x).**
> **如上图所示，当查找到的论文超过 10 篇时，程序会自动拆分成多个卡片发送。**